### PR TITLE
Add git hook & convenience alias

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,17 @@
+#!/bin/sh
+#
+# To install ruff checks on .py files globally:
+# git config --global core.hooksPath "/c/Instrument/dev/reusable-workflows/.hooks"
+#
+set -e
+
+# Run local pre-commit hooks if defined
+if [ -f "$(git rev-parse --git-dir)/hooks/pre-commit" ]; then
+   . "$(git rev-parse --git-dir)/hooks/pre-commit"
+fi
+
+RUFF="/c/Instrument/Apps/Python3/Scripts/ruff"
+RUFF_CONFIG="/c/Instrument/dev/reusable-workflows/ruff.toml"
+
+git diff --cached --name-only --diff-filter=ACM -z | grep -zZE ".py$" | xargs -0 --no-run-if-empty $RUFF format --check --config $RUFF_CONFIG
+git diff --cached --name-only --diff-filter=ACM -z | grep -zZE ".py$" | xargs -0 --no-run-if-empty $RUFF check --config $RUFF_CONFIG

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -13,5 +13,5 @@ fi
 RUFF="/c/Instrument/Apps/Python3/Scripts/ruff"
 RUFF_CONFIG="/c/Instrument/dev/reusable-workflows/ruff.toml"
 
-git diff --cached --name-only --diff-filter=ACM -z | grep -zZE ".py$" | xargs -0 --no-run-if-empty $RUFF format --check --config $RUFF_CONFIG
-git diff --cached --name-only --diff-filter=ACM -z | grep -zZE ".py$" | xargs -0 --no-run-if-empty $RUFF check --config $RUFF_CONFIG
+git diff --cached --name-only --diff-filter=ACM -z | grep -zZE "\.py$" | xargs -0 --no-run-if-empty $RUFF format --check --config $RUFF_CONFIG
+git diff --cached --name-only --diff-filter=ACM -z | grep -zZE "\.py$" | xargs -0 --no-run-if-empty $RUFF check --config $RUFF_CONFIG

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -13,5 +13,5 @@ fi
 RUFF="/c/Instrument/Apps/Python3/Scripts/ruff"
 RUFF_CONFIG="/c/Instrument/dev/reusable-workflows/ruff.toml"
 
-git diff --cached --name-only --diff-filter=ACM -z | grep -zZE "\.py$" | xargs -0 --no-run-if-empty $RUFF format --check --config $RUFF_CONFIG
-git diff --cached --name-only --diff-filter=ACM -z | grep -zZE "\.py$" | xargs -0 --no-run-if-empty $RUFF check --config $RUFF_CONFIG
+git diff --cached --name-only --diff-filter=ACM -z "*.py" | xargs -0 --no-run-if-empty $RUFF format --check --config $RUFF_CONFIG
+git diff --cached --name-only --diff-filter=ACM -z "*.py" | xargs -0 --no-run-if-empty $RUFF check --config $RUFF_CONFIG

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -11,7 +11,13 @@ if [ -f "$(git rev-parse --git-dir)/hooks/pre-commit" ]; then
 fi
 
 RUFF="/c/Instrument/Apps/Python3/Scripts/ruff"
-RUFF_CONFIG="/c/Instrument/dev/reusable-workflows/ruff.toml"
+
+# Respect repo-local ruff.toml if available
+if [ -f "$(git rev-parse --git-dir)/../ruff.toml" ]; then
+    RUFF_CONFIG="$(git rev-parse --git-dir)/../ruff.toml"
+else
+    RUFF_CONFIG="/c/Instrument/dev/reusable-workflows/ruff.toml"
+fi
 
 git diff --cached --name-only --diff-filter=ACM -z "*.py" | xargs -0 --no-run-if-empty $RUFF format --check --config $RUFF_CONFIG
 git diff --cached --name-only --diff-filter=ACM -z "*.py" | xargs -0 --no-run-if-empty $RUFF check --config $RUFF_CONFIG

--- a/README.md
+++ b/README.md
@@ -41,6 +41,35 @@ We also ignore the following  rules on test files as they should have self-docum
 |D102 | Missing docstring in public method |
 |E501 | Line too long. |
 
+#### Local configuration: git hook
+
+A git hook is available in the `.hooks` folder of this repository, which calls ruff on any modified python files on commit, and will prevent commiting if ruff checks fail.
+
+The pre-commit hook assumes that you have checked out the `reusable-workflows` repository to `c:\instrument\dev\reusable-workflows`. To enable the hook globally on your machine, run:
+```
+git config --global core.hooksPath "/c/Instrument/dev/reusable-workflows/.hooks"
+```
+
+The git hook will respect the settings in repo-local `ruff.toml` files, and like the build server, will only check modified files. 
+
+It will also respect any other pre-commit hooks defined in the repository.
+
+#### Local configuration: convenience script
+
+There is a script, `r.bat`, in `./scripts` that will invoke ruff for convenience. Like the git hook, it respects repo-local `ruff.toml` files.
+
+After adding `c:\instrument\dev\reusable-workflows\scripts` to your `PATH`, it can be executed as:
+```
+r format --check
+r format
+r check
+```
+
+Unlike the git hook, this will check all files by default. You can pass the script an explicit list of files:
+```
+r format --check c:\path\to\some\file.py
+```
+
 ### Pyright
 The Pyright linter uses diff_cover and the [pyright diff-cover plugin](https://github.com/DiamondLightSource/pyright_diff_quality_plugin) to run pyright on files that have changed.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ The git hook will respect the settings in repo-local `ruff.toml` files, and like
 
 It will also respect any other pre-commit hooks defined in the repository.
 
+Note that if you then need to explicitly bypass these checks (e.g. you are committing to an external repository that does not use our coding standards), you will then need to pass `--no-verify` to your `git commit` commands to disable git hooks.
+
 #### Local configuration: convenience script
 
 There is a script, `r.bat`, in `./scripts` that will invoke ruff for convenience. Like the git hook, it respects repo-local `ruff.toml` files.

--- a/scripts/r.bat
+++ b/scripts/r.bat
@@ -1,4 +1,6 @@
 @echo off
+IF "%1"=="" GOTO HAVE_0_ARGS
+
 FOR /F "delims=" %%i IN ('git rev-parse --git-dir') DO set REUSABLE_WF_GITDIR=%%i
 if exist "%REUSABLE_WF_GITDIR%/../ruff.toml" (
   set "REUSABLE_WF_RUFF_CONFIG=%REUSABLE_WF_GITDIR%/../ruff.toml"
@@ -7,3 +9,6 @@ if exist "%REUSABLE_WF_GITDIR%/../ruff.toml" (
 )
 c:\instrument\apps\Python3\scripts\ruff %* --config="%REUSABLE_WF_RUFF_CONFIG%"
 exit /b %errorlevel%
+
+:HAVE_0_ARGS
+echo "Usage: either 'r check' or 'r format'"

--- a/scripts/r.bat
+++ b/scripts/r.bat
@@ -1,0 +1,9 @@
+@echo off
+FOR /F "delims=" %%i IN ('git rev-parse --git-dir') DO set REUSABLE_WF_GITDIR=%%i
+if exist "%REUSABLE_WF_GITDIR%/../ruff.toml" (
+  set "REUSABLE_WF_RUFF_CONFIG=%REUSABLE_WF_GITDIR%/../ruff.toml"
+) else (
+  set "REUSABLE_WF_RUFF_CONFIG=%~dp0\..\ruff.toml"
+)
+c:\instrument\apps\Python3\scripts\ruff %* --config="%REUSABLE_WF_RUFF_CONFIG%"
+exit /b %errorlevel%


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/8514

Idea for a global git hook for devs, implementing the same checks as the CI server.

Will likely need to exclude certain things - e.g. python2 code in OPIs in GUI, that should probably be done in a custom `ruff.toml` in each relevant repo.