### PR TITLE
Remove ANN101 and ANN102 following removal from `ruff`

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -48,8 +48,6 @@ ignore = [
     "D406",  # Section name should end with a newline ("{name}")
     "D407",  # Missing dashed underline after section ("{name}")
     "N999",  # Ignore this because the repo itself would need to be renamed
-    "ANN101",  # ignore this until its removed in future versions
-    "ANN102",  # ignore this until its removed in future versions
 ]
 [lint.per-file-ignores]
 "{**/tests/**,/tests/**,**/*tests.py,tests/**,*tests.py,*test.py,**/*test.py,common_tests/**,test_*.py}" = [


### PR DESCRIPTION
`ruff>=0.8.0` no longer has these rules and emits a warning if you mention them in `ruff.toml`.

After merge, post in `dev-changes-memo` telling people to:
- Run `c:\instrument\apps\python3\python.exe -m pip install --upgrade ruff` to get new ruff version
- Run `git pull` in `c:\instrument\dev\reusable-workflows` to get the new config locally