### PR TITLE
Update per-file ignores for common_tests in a sub-directory

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -50,7 +50,7 @@ ignore = [
     "N999",  # Ignore this because the repo itself would need to be renamed
 ]
 [lint.per-file-ignores]
-"{**/tests/**,/tests/**,**/*tests.py,tests/**,*tests.py,*test.py,**/*test.py,common_tests/**,test_*.py}" = [
+"{**/tests/**,/tests/**,**/*tests.py,tests/**,*tests.py,*test.py,**/*test.py,common_tests/**,**/common_tests/**,test_*.py}" = [
     "N802",
     "D100",
     "D101",


### PR DESCRIPTION
This is to allow `system_tests/common_tests` to be picked up in cases like https://github.com/ISISComputingGroup/EPICS-Aeroflex/tree/main/system_tests